### PR TITLE
parser/schema: switch strtol to strtoul

### DIFF
--- a/src/core/parse/schema.c
+++ b/src/core/parse/schema.c
@@ -45,7 +45,7 @@ hound_data_id parse_num(const char *s)
     hound_data_id id;
 
     errno = 0;
-    id = strtol(s, NULL, 0);
+    id = strtoul(s, NULL, 0);
     XASSERT_OK(errno);
 
     return id;


### PR DESCRIPTION
`hound_data_id` is typedef'd to an unsigned type, we should use the appropriate string parser to
handle 2^31 <= n < 2^32.